### PR TITLE
Conecta muralmalvinas a la red bridge

### DIFF
--- a/start.sh
+++ b/start.sh
@@ -14,3 +14,4 @@ docker run -d -p 8081 \
  -e "HTTPS_METHOD=nohttps" \
  -e "VIRTUAL_PORT=8081" \
  -d decyt/muralmalvinas
+docker network connect bridge muralmalvinas


### PR DESCRIPTION
muralmalvinas y muraldb se conectan mutuamente dentro de la red
panel-net. Para que el reverse proxy pueda conectarse al mural, es
necesario conectar muralmalvinas a la red bridge.